### PR TITLE
Upgrade to LLVM 15 and LLVM 16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,11 @@ message(STATUS "LLVM Config: ASSERTIONS:${LLVM_ENABLE_ASSERTIONS}, "
 
 # Depends on how clang was compiled, by default it's set to C++14
 # https://llvm.org/docs/CMake.html#rarely-used-cmake-variables
-set(CMAKE_CXX_STANDARD 14)
+if (LLVM_PACKAGE_VERSION VERSION_LESS "16.0.0")
+  set(CMAKE_CXX_STANDARD 14)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 if (LLVM_ENABLE_LIBCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")

--- a/bogus/BogusControlFlow.cpp
+++ b/bogus/BogusControlFlow.cpp
@@ -627,8 +627,8 @@ bool BogusControlFlow::doF(Module &M) {
   for (std::vector<Instruction *>::iterator i = toEdit.begin();
        i != toEdit.end(); ++i) {
     // if y < 10 || x*(x+1) % 2 == 0
-    opX = new LoadInst(x->getType()->getPointerElementType(), (Value *)x, "", (*i));
-    opY = new LoadInst(y->getType()->getPointerElementType(), (Value *)y, "", (*i));
+    opX = new LoadInst(x->getValueType(), (Value *)x, "", (*i));
+    opY = new LoadInst(y->getValueType(), (Value *)y, "", (*i));
 
     op = BinaryOperator::Create(
         Instruction::Sub, (Value *)opX,

--- a/flattening/Flattening.cpp
+++ b/flattening/Flattening.cpp
@@ -107,7 +107,7 @@ bool Flattening::flatten(Function *f) {
   loopEntry = BasicBlock::Create(f->getContext(), "loopEntry", f, insert);
   loopEnd = BasicBlock::Create(f->getContext(), "loopEnd", f, insert);
 
-  load = new LoadInst(switchVar->getType()->getPointerElementType(), switchVar,
+  load = new LoadInst(switchVar->getAllocatedType(), switchVar,
                       "switchVar", loopEntry);
 
   // Move first BB on top

--- a/substitution/Substitution.cpp
+++ b/substitution/Substitution.cpp
@@ -14,6 +14,7 @@
 
 #include "Substitution.h"
 #include "utils/Utils.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/CommandLine.h"

--- a/utils/Utils.cpp
+++ b/utils/Utils.cpp
@@ -1,4 +1,5 @@
 #include "Utils.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
 #include <sstream>


### PR DESCRIPTION
Long overdue upgrade with new versions of LLVM

Notable changes are:

 - LLVM now require C++17
 - Deprecation of [OpaquePointers](https://llvm.org/docs/OpaquePointers.html)

Build to be checked with:
 - [x] LLVM 16
 - [x] LLVM 15
 - [x] LLVM 14
 - [ ] LLVM 13
 - [ ] LLVM 12
 - [ ] LLVM Android NDK (version ?)
 - [x] LLVM Rust Stable (1.70.0)

Mostly to be tested on:
 - [x] C (openssl)
 - [ ] C++ (llvm)
 - [ ] Rust (alloy-rs/core)
 - [ ] Android NDK arm64 (openssl)

| Test \ Pass      | sub | split | fla | bogus | str | all passes together |
|---                      |---     |---      |---   | ---        |---   |---                                 |
| C (openssl)     | ~     | ~       | ~    | ~         | ~    | OK                              |
| C++ (llvm)       | ~     | ~       | ~    | ~         | ~    |                                    |
| rust (alloy)      | ~     | ~       | ~    | ~         | ~    |                                    |
| ndk (openssl) | ~     | ~       | ~    | ~         | ~    |                                    |
