### PR TITLE
Fix build for ARM/AARCH64 hosts

### DIFF
--- a/utils/CryptoUtils.h
+++ b/utils/CryptoUtils.h
@@ -74,6 +74,24 @@ extern ManagedStatic<CryptoUtils> cryptoutils;
 #define ENDIAN_32BITWORD
 #endif
 
+#elif defined(__arm__) || defined(__aarch64__)
+
+#if defined(__ARM_BIG_ENDIAN)
+#ifndef ENDIAN_BIG
+#define ENDIAN_BIG
+#endif
+#else
+#ifndef ENDIAN_LITTLE
+#define ENDIAN_LITTLE
+#endif
+#endif
+
+#if defined(__ARM_ARCH_ISA_A64)
+#define ENDIAN_64BITWORD
+#else
+#define ENDIAN_32BITWORD
+#endif
+
 #endif
 
 //#if defined(__BIG_ENDIAN__) || defined(_BIG_ENDIAN)


### PR DESCRIPTION
Fixes GH-19

checking on aarch64

Not sure about ARM32, a rpi would not manage to compile LLVM+plugin ...

Macros at  https://developer.arm.com/documentation/dui0774/g/chr1383660321827